### PR TITLE
Fehlerbehebung für ungültige Mail-Adressen

### DIFF
--- a/lib/introduction.dart
+++ b/lib/introduction.dart
@@ -404,7 +404,7 @@ class _LernSaxScreenMainState extends State<LernSaxScreenMain> {
     if (_mailController.text.trim() == "" && _triedToEnter) {
       return "Keine E-Mail-Adresse angegeben.";
     } else if (_triedToEnter) {
-      RegExp regex = RegExp(r"^[a-z]*(?:.(?:" + parentTypeEndings.join("|") + r"))?@jkgc\.lernsax\.de$", multiLine: true, caseSensitive: false);
+      RegExp regex = RegExp(r"^[a-z0-9]*(?:.(?:" + parentTypeEndings.join("|") + r"))?@jkgc\.lernsax\.de$", multiLine: true, caseSensitive: false);
       if (!regex.hasMatch(_mailController.text)) return "Ungültige LernSax-E-Mail-Adresse.";
     }
     return null;


### PR DESCRIPTION
Es wurde keine Zahl im Benutzername akzeptiert.